### PR TITLE
For 持其它插件中显示403无权限页面

### DIFF
--- a/src/plugin/admin/app/middleware/AccessControl.php
+++ b/src/plugin/admin/app/middleware/AccessControl.php
@@ -21,6 +21,11 @@ class AccessControl implements MiddlewareInterface
         $controller = $request->controller;
         $action = $request->action;
 
+        $plugin=$request->plugin;
+        $app=$request->app;
+        $request->plugin='admin';
+        $request->app='';
+
         $code = 0;
         $msg = '';
         if (!Auth::canAccess($controller, $action, $code, $msg)) {
@@ -42,6 +47,8 @@ EOF
             }
 
         } else {
+            $request->plugin=$plugin;
+            $request->app=$app;
             $response = $request->method() == 'OPTIONS' ? response('') : $handler($request);
         }
 


### PR DESCRIPTION
app 没有重置、还是用不了自带的403 页面