### PR TITLE
修改crud查找条件为in或not in查询

### DIFF
--- a/src/plugin/admin/app/controller/Crud.php
+++ b/src/plugin/admin/app/controller/Crud.php
@@ -101,6 +101,7 @@ class Crud extends Base
         }
         foreach ($where as $column => $value) {
             if ($value === '' || !isset($allow_column[$column]) ||
+                (is_array($value) && (count($value) <= 1)) ||
                 (is_array($value) && (in_array($value[0], ['', 'undefined']) || in_array($value[1], ['', 'undefined'])))) {
                 unset($where[$column]);
             }
@@ -134,10 +135,20 @@ class Crud extends Base
                 } elseif (in_array($value[0], ['>', '=', '<', '<>', 'not like'])) {
                     $model = $model->where($column, $value[0], $value[1]);
                 } elseif ($value[0] == 'in') {
-                    $model = $model->whereIn($column, $value[1]);
+                    if (is_string($value[1])) {
+                        $valArr = explode(",", trim($value[1]));
+                        $valArr && $model = $model->whereIn($column, $valArr);
+                    } else {
+                        $model = $model->whereIn($column, $value[1]);
+                    }
                 } elseif ($value[0] == 'not in') {
-                    $model = $model->whereNotIn($column, $value[1]);
-                } elseif ($value[0] == 'null') {
+                    if (is_string($value[1])) {
+                        $valArr = explode(",", trim($value[1]));
+                        $valArr && $model = $model->whereNotIn($column, $valArr);
+                    } else {
+                        $model = $model->whereNotIn($column, $value[1]);
+                    }
+                }elseif ($value[0] == 'null') {
                     $model = $model->whereNull($column, $value[1]);
                 } elseif ($value[0] == 'not null') {
                     $model = $model->whereNotNull($column, $value[1]);


### PR DESCRIPTION
1.修改crud查找条件为in或not in时，值使用,分割成数组，可以完美搭配xmSelect的tree进行多单位搜索
2.修复查询条件为非法数组时异常，即类似['in']的条件