### PR TITLE
fix:过滤菜单后数据结构异常

### DIFF
--- a/src/plugin/admin/app/controller/RuleController.php
+++ b/src/plugin/admin/app/controller/RuleController.php
@@ -282,6 +282,7 @@ class RuleController extends Crud
                 $this->removeNotContain($item['children'], $key, $values);
             }
         }
+        $array = array_values($array);
     }
 
     /**


### PR DESCRIPTION
![image](https://github.com/webman-php/admin/assets/25134062/558393a7-a165-4d59-8a1f-22ff0c7a6a23)
过滤菜单后，原索引数组变成了枚举数组，导致JSON中原数组变成了对象，排查JS代码有用到 `children.length` 导致无法渲染子菜单