### PR TITLE
当首个菜单数据无 children 时，菜单数组下标不会被重建

### DIFF
--- a/src/plugin/admin/app/common/Tree.php
+++ b/src/plugin/admin/app/common/Tree.php
@@ -168,7 +168,7 @@ class Tree
         }
         if (!isset($array['children'])) {
             $current = current($array);
-            if (!is_array($current) || !isset($current['children'])) {
+            if (!is_array($current)) {
                 return $array;
             }
             $tree = array_values($array);

--- a/src/plugin/admin/app/controller/RuleController.php
+++ b/src/plugin/admin/app/controller/RuleController.php
@@ -282,6 +282,7 @@ class RuleController extends Crud
                 $this->removeNotContain($item['children'], $key, $values);
             }
         }
+        $array = array_values($array);
     }
 
     /**

--- a/src/plugin/admin/app/controller/RuleController.php
+++ b/src/plugin/admin/app/controller/RuleController.php
@@ -282,7 +282,6 @@ class RuleController extends Crud
                 $this->removeNotContain($item['children'], $key, $values);
             }
         }
-        $array = array_values($array);
     }
 
     /**


### PR DESCRIPTION
当首个菜单数据无 children 时，菜单数组下标不会被重建。导致前端渲染异常