### PR TITLE
fix: 解决/url/select?format=table_tree 的bug

### DIFF
--- a/src/plugin/admin/app/common/Tree.php
+++ b/src/plugin/admin/app/common/Tree.php
@@ -44,6 +44,12 @@ class Tree
             $this->data = $data->toArray();
         } else {
             $this->data = (array)$data;
+            $this->data = array_map(function ($item) {
+                if (is_object($item) && method_exists($item, 'toArray')) {
+                    return $item->toArray();
+                }
+                return $item;
+            }, $this->data);
         }
         $this->hashTree = $this->getHashTree();
     }


### PR DESCRIPTION
bug 出现的时机：
当请求的url为 /unit/select?format=table_tree 时，会报错，错误提示：
```
ErrorException: Indirect modification of overloaded element of app\model\UnitTree has no effect in D:\4.PHP\Code\webman-zbcms\plugin\admin\app\common\Tree.php:101
Stack trace:
#0 D:\4.PHP\Code\webman-zbcms\plugin\admin\app\common\Tree.php(101): support\App::{closure}(8, 'Indirect modifi...', 'D:\\4.PHP\\Code\\w...', 101)
#1 D:\4.PHP\Code\webman-zbcms\plugin\admin\app\common\Tree.php(55): plugin\admin\app\common\Tree->getHashTree()
```
原因是因为，在[Crud.php获取items时](https://github.com/webman-php/admin/blob/ed9aa931ac41c3fba0c3700845f9524946cc26d5/src/plugin/admin/app/controller/Crud.php#L184)，得到的是一个外面是数组，里面是一个对象app\model\UnitTree的 Object， 在[Tree的构造函数中](https://github.com/webman-php/admin/blob/ed9aa931ac41c3fba0c3700845f9524946cc26d5/src/plugin/admin/app/common/Tree.php#L46)，这句转为数组的代码就不会起到作用了。
本人拙劣的改了一下，仅供参考。

