### PR TITLE
refactor(admin): 允许字典名称包含下划线

### DIFF
--- a/src/plugin/admin/app/controller/DictController.php
+++ b/src/plugin/admin/app/controller/DictController.php
@@ -66,8 +66,8 @@ class DictController extends Base
             if (Dict::get($name)) {
                 return $this->json(1, '字典已经存在');
             }
-            if (!preg_match('/^[a-zA-Z0-9]+$/', $name)) {
-                return $this->json(2, '字典名称只能是字母数字的组合');
+            if (!preg_match('/^[a-zA-Z0-9_]+$/', $name)) {
+                return $this->json(2, '字典名称只能是字母数字下划线的组合');
             }
             $values = (array)$request->post('value', []);
             Dict::save($name, $values);
@@ -88,8 +88,8 @@ class DictController extends Base
             if (!Dict::get($name)) {
                 return $this->json(1, '字典不存在');
             }
-            if (!preg_match('/^[a-zA-Z0-9]+$/', $name)) {
-                return $this->json(2, '字典名称只能是字母数字的组合');
+            if (!preg_match('/^[a-zA-Z0-9_]+$/', $name)) {
+                return $this->json(2, '字典名称只能是字母数字下划线的组合');
             }
             Dict::save($name, $request->post('value'));
         }


### PR DESCRIPTION
- 修改了 DictController 中的正则表达式，允许字典名称包含下划线字符
- 更新了错误提示信息，明确字典名称可以包含字母、数字和下划线