### PR TITLE
refactor(admin): 优化图片上传组件的 multiple 属性处理逻辑- 将 $props['multiple'] 的处理方式从三元运算符改为使用 null 合并运算符 - 这种写法更加简洁，并且在 $props['multiple'] 未设置时默认将其设为 0

### DIFF
--- a/src/plugin/admin/app/common/Layui.php
+++ b/src/plugin/admin/app/common/Layui.php
@@ -369,7 +369,7 @@ EOF;
         [$label, $field, $value, $props, $verify_string, $required_string, $class] = $this->options($options);
         $props['acceptMime'] = $props['acceptMime'] ?? 'image/gif,image/jpeg,image/jpg,image/png';
         $props['url'] = $props['url'] ?? '/app/admin/upload/image';
-        $props['multiple'] = $props['multiple'] ? 1 : 0;
+        $props['multiple'] = $props['multiple'] ?? 0;
 
         $id = $this->createId($field);
 

--- a/src/plugin/admin/app/common/Layui.php
+++ b/src/plugin/admin/app/common/Layui.php
@@ -1070,12 +1070,17 @@ EOF;
 EOF;
                     } else {
                         $templet = <<<EOF
+
 		                templet: function (d) {
-                            const images = d['$field'].split(',');
-                            let html = '';
+		                    let html = '';
+		                    if(d['$field']){
+		                    const images = d['$field'].split(',');
+                        
                             for (let img of images) {
                                 html += '<img src="' + encodeURI(img.trim()) + '" style="max-width:32px;max-height:32px;" alt="" />';
                             }
+		                    }
+                            
                             return html;
 						}
 EOF;

--- a/src/plugin/admin/app/controller/DictController.php
+++ b/src/plugin/admin/app/controller/DictController.php
@@ -66,8 +66,8 @@ class DictController extends Base
             if (Dict::get($name)) {
                 return $this->json(1, '字典已经存在');
             }
-            if (!preg_match('/^[a-zA-Z0-9]+$/', $name)) {
-                return $this->json(2, '字典名称只能是字母数字的组合');
+            if (!preg_match('/^[a-zA-Z0-9_]+$/', $name)) {
+                return $this->json(2, '字典名称只能是字母数字下划线的组合');
             }
             $values = (array)$request->post('value', []);
             Dict::save($name, $values);
@@ -88,8 +88,8 @@ class DictController extends Base
             if (!Dict::get($name)) {
                 return $this->json(1, '字典不存在');
             }
-            if (!preg_match('/^[a-zA-Z0-9]+$/', $name)) {
-                return $this->json(2, '字典名称只能是字母数字的组合');
+            if (!preg_match('/^[a-zA-Z0-9_]+$/', $name)) {
+                return $this->json(2, '字典名称只能是字母数字下划线的组合');
             }
             Dict::save($name, $request->post('value'));
         }


### PR DESCRIPTION
refactor(admin): 优化图片上传组件的 multiple 属性处理逻辑- 将 $props['multiple'] 的处理方式从三元运算符改为使用 null 合并运算符
- 这种写法更加简洁，并且在 $props['multiple'] 未设置时默认将其设为 0