### PR TITLE
feat(common): 添加按钮类名兼容性处理功能

### DIFF
--- a/src/plugin/admin/public/js/common.js
+++ b/src/plugin/admin/public/js/common.js
@@ -32,6 +32,51 @@ function toggleSearchFormShow()
     $('.top-search-from .toggle-btn a:first').addClass('layui-hide');
 }
 
+// TODO 将来删除
+function compatible()
+{
+    [
+        ['pear-btn-xs', 'layui-btn-xs'],
+        ['pear-btn-sm', 'layui-btn-sm'],
+        ['pear-btn-lg', 'layui-btn-lg'],
+        ['pear-btn', 'layui-btn'],
+    ].forEach(([old_class,new_class]) => {
+        document.querySelectorAll(`.${old_class}:not(.${new_class})`).forEach(item=>{
+            item.classList.add(new_class);
+        });
+    })
+}
+
+// 优化后的兼容性处理
+function optimizedCompatible()
+{
+    // 初始化执行一次
+    compatible();
+
+    // 现代浏览器使用 MutationObserver
+    if ('MutationObserver' in window) {
+        const observer = new MutationObserver(() => compatible());
+        observer.observe(document.body, { childList: true, subtree: true });
+        window.compatibleObserver = observer;
+        return;
+    }
+
+    // 老浏览器使用节流定时器
+    let timer = null;
+    const handler = () => {
+        if (timer) return;
+        timer = setTimeout(() => {
+            compatible();
+            timer = null;
+        }, 1000);
+    };
+
+    document.addEventListener('DOMNodeInserted', handler);
+    window.throttledCompatible = handler;
+}
+
 layui.$(function () {
     toggleSearchFormShow();
+    optimizedCompatible();
 });
+

--- a/src/plugin/admin/public/js/common.js
+++ b/src/plugin/admin/public/js/common.js
@@ -32,51 +32,6 @@ function toggleSearchFormShow()
     $('.top-search-from .toggle-btn a:first').addClass('layui-hide');
 }
 
-// TODO 将来删除
-function compatible()
-{
-    [
-        ['pear-btn-xs', 'layui-btn-xs'],
-        ['pear-btn-sm', 'layui-btn-sm'],
-        ['pear-btn-lg', 'layui-btn-lg'],
-        ['pear-btn', 'layui-btn'],
-    ].forEach(([old_class,new_class]) => {
-        document.querySelectorAll(`.${old_class}:not(.${new_class})`).forEach(item=>{
-            item.classList.add(new_class);
-        });
-    })
-}
-
-// 优化后的兼容性处理
-function optimizedCompatible()
-{
-    // 初始化执行一次
-    compatible();
-
-    // 现代浏览器使用 MutationObserver
-    if ('MutationObserver' in window) {
-        const observer = new MutationObserver(() => compatible());
-        observer.observe(document.body, { childList: true, subtree: true });
-        window.compatibleObserver = observer;
-        return;
-    }
-
-    // 老浏览器使用节流定时器
-    let timer = null;
-    const handler = () => {
-        if (timer) return;
-        timer = setTimeout(() => {
-            compatible();
-            timer = null;
-        }, 1000);
-    };
-
-    document.addEventListener('DOMNodeInserted', handler);
-    window.throttledCompatible = handler;
-}
-
 layui.$(function () {
     toggleSearchFormShow();
-    optimizedCompatible();
 });
-

--- a/src/plugin/admin/public/js/permission.js
+++ b/src/plugin/admin/public/js/permission.js
@@ -32,3 +32,48 @@ layui.$(function () {
         }
     });
 });
+
+// TODO 将来应该删除
+function compatible()
+{
+    [
+        ['pear-btn-xs', 'layui-btn-xs'],
+        ['pear-btn-sm', 'layui-btn-sm'],
+        ['pear-btn-lg', 'layui-btn-lg'],
+        ['pear-btn', 'layui-btn'],
+    ].forEach(([old_class,new_class]) => {
+        document.querySelectorAll(`.${old_class}:not(.${new_class})`).forEach(item=>{
+            item.classList.add(new_class);
+        });
+    })
+}
+
+// 优化后的兼容性处理
+function optimizedCompatible()
+{
+    // 初始化执行一次
+    compatible();
+
+    // 现代浏览器使用 MutationObserver
+    if ('MutationObserver' in window) {
+        const observer = new MutationObserver(() => compatible());
+        observer.observe(document.body, { childList: true, subtree: true });
+        window.compatibleObserver = observer;
+        return;
+    }
+
+    // 老浏览器使用节流定时器
+    let timer = null;
+    const handler = () => {
+        if (timer) return;
+        timer = setTimeout(() => {
+            compatible();
+            timer = null;
+        }, 1000);
+    };
+
+    document.addEventListener('DOMNodeInserted', handler);
+    window.throttledCompatible = handler;
+}
+
+requestAnimationFrame(optimizedCompatible);


### PR DESCRIPTION
- 实现了 pear-btn 到 layui-btn 的类名转换兼容
- 添加了 MutationObserver 监听 DOM 变化并自动处理
- 针对老浏览器提供了节流定时器回退方案
- 自动初始化执行一次兼容性处理
- 支持动态插入元素的类名自动转换