### PR TITLE
优化后台分割菜单下的顶部菜单文字的不必要颜色申明

### DIFF
--- a/src/plugin/admin/public/admin/css/admin.css
+++ b/src/plugin/admin/public/admin/css/admin.css
@@ -206,10 +206,6 @@ body,
 	color: white !important;
 }
 
-.pear-admin .auto-theme .layui-nav.pear-nav-control .layui-this * {
-	color: black !important;
-}
-
 .pear-admin .auto-theme .layui-nav .layui-nav-child a {
 	color: #5f5f5f !important;
 	color: rgba(0, 0, 0, .8) !important;


### PR DESCRIPTION
此颜色设置会影响在暗色模式下的文字显示，造成文字无法阅读