### PR TITLE
fix: 移除 layui.use 异步包裹，解决表单提交索引字段丢失问题

### DIFF
--- a/src/plugin/admin/app/view/table/modify.html
+++ b/src/plugin/admin/app/view/table/modify.html
@@ -646,30 +646,27 @@
                             }
 
                             window.keyColumnMultiSelectRender = function () {
-                                layui.use(["jquery", "xmSelect", "table"], function () {
-                                    let $ = layui.$;
-                                    let table = layui.table;
-                                    let columnData = table.getData("column-table");
-                                    let data = [];
-                                    layui.each(columnData, function (i, item) {
-                                        if (item.field) {
-                                            data.push({
-                                                name: item.field, value:item.field
-                                            });
-                                        }
-                                    });
-                                    layui.each($(".key-columns-div"), function (_, dom) {
-                                        let name = $(dom).attr("name");
-                                        let value = $(dom).attr("value");
-                                        let initValue = value ? value.split(",") : [];
-                                        layui.xmSelect.render({
-                                            el: dom,
-                                            name: name,
-                                            initValue: initValue,
-                                            data: data,
-                                        })
-                                    });
-
+                                let $ = layui.$;
+                                let table = layui.table;
+                                let columnData = table.getData("column-table");
+                                let data = [];
+                                layui.each(columnData, function (i, item) {
+                                    if (item.field) {
+                                        data.push({
+                                            name: item.field, value:item.field
+                                        });
+                                    }
+                                });
+                                layui.each($(".key-columns-div"), function (_, dom) {
+                                    let name = $(dom).attr("name");
+                                    let value = $(dom).attr("value");
+                                    let initValue = value ? value.split(",") : [];
+                                    layui.xmSelect.render({
+                                        el: dom,
+                                        name: name,
+                                        initValue: initValue,
+                                        data: data,
+                                    })
                                 });
                             }
 


### PR DESCRIPTION
问题描述
在 syncTableData() 执行表格重载后，表单提交时 form.val 无法获取 keys[0][columns] 的值（索引字段丢失）。

{
    "code": 500,
    "msg": "Undefined array key \"columns\"",
    "type": "failed",
    "traces": "ErrorException: Undefined array key \"columns\" in H:\\go_project\\workerman\\webman\\plugin\\admin\\app\\controller\\TableController.php:267\nStack trace:\n#0 H:\\go_project\\workerman\\webman\\plugin\\admin\\app\\controller\\TableController.php(267): {closure}(2, 'Undefined array...', 'H:\\\\go_project\\\\w...', 267)\n#1 H:\\go_project\\workerman\\webman\\vendor\\workerman\\webman-framework\\src\\App.php(428): plugin\\admin\\app\\controller\\TableController->modify(Object(support\\Request))\n#2 H:\\go_project\\workerman\\webman\\vendor\\workerman\\webman-framework\\src\\App.php(444): Webman\\App::Webman\\{closure}(Object(support\\Request))\n#3 H:\\go_project\\workerman\\webman\\plugin\\admin\\app\\middleware\\AccessControl.php(40): Webman\\App::Webman\\{closure}(Object(support\\Request))\n#4 H:\\go_project\\workerman\\webman\\vendor\\workerman\\webman-framework\\src\\App.php(468): plugin\\admin\\app\\middleware\\AccessControl->process(Object(support\\Request), Object(Closure))\n#5 H:\\go_project\\workerman\\webman\\vendor\\workerman\\webman-framework\\src\\App.php(198): Webman\\App::Webman\\{closure}(Object(support\\Request))\n#6 H:\\go_project\\workerman\\webman\\vendor\\workerman\\workerman\\src\\Connection\\TcpConnection.php(816): Webman\\App->onMessage(Object(Workerman\\Connection\\TcpConnection), Object(support\\Request))\n#7 H:\\go_project\\workerman\\webman\\vendor\\workerman\\workerman\\src\\Events\\Select.php(406): Workerman\\Connection\\TcpConnection->baseRead(Resource id #684)\n#8 H:\\go_project\\workerman\\webman\\vendor\\workerman\\workerman\\src\\Worker.php(1620): Workerman\\Events\\Select->run()\n#9 H:\\go_project\\workerman\\webman\\vendor\\workerman\\workerman\\src\\Worker.php(1536): Workerman\\Worker::forkWorkersForWindows()\n#10 H:\\go_project\\workerman\\webman\\vendor\\workerman\\workerman\\src\\Worker.php(603): Workerman\\Worker::forkWorkers()\n#11 H:\\go_project\\workerman\\webman\\runtime\\windows\\start_webman.php(33): Workerman\\Worker::runAll()\n#12 {main}"
}

复现步骤
表单中使用 xmSelect 组件作为索引字段；
触发表格重载（如 syncTableData()）；
提交表单，form.val 返回的数据中缺少 keys[0][columns]。

解决方案

移除 keyColumnMultiSelectRender 函数内的 layui.use 异步包裹，使 xmSelect.render 同步执行，确保 DOM 渲染完成后再收集表单数据。

测试结果
验证方法：本地启动项目，复现问题步骤，提交表单后检查 form.val 是否包含 keys[0][columns]。
结果：修改后，form.val 正确获取索引字段值，问题解决。
副作用检查：未影响 jquery、table 等模块的正常使用，xmSelect 渲染功能正常。